### PR TITLE
Allow format empty response

### DIFF
--- a/src/DataResponse.php
+++ b/src/DataResponse.php
@@ -36,12 +36,12 @@ final class DataResponse implements ResponseInterface
             return $this->dataStream;
         }
 
-        if ($this->data === null) {
+        if ($this->responseFormatter !== null) {
+            $this->response = $this->responseFormatter->format($this);
             return $this->dataStream = $this->response->getBody();
         }
 
-        if ($this->responseFormatter !== null) {
-            $this->response = $this->responseFormatter->format($this);
+        if ($this->data === null) {
             return $this->dataStream = $this->response->getBody();
         }
 

--- a/tests/DataResponseTest.php
+++ b/tests/DataResponseTest.php
@@ -54,9 +54,10 @@ class DataResponseTest extends TestCase
         $factory = new Psr17Factory();
         $dataResponse = new DataResponse(null, Status::OK, '', $factory);
         $dataResponse = $dataResponse->withResponseFormatter(new JsonDataResponseFormatter());
+        $dataResponse->getBody()->rewind();
 
         $this->assertTrue($dataResponse->hasResponseFormatter());
-        $this->assertSame('', $dataResponse->getBody()->getContents());
+        $this->assertSame('null', $dataResponse->getBody()->getContents());
         $this->assertSame(['application/json'], $dataResponse->getHeader('Content-Type'));
     }
 }

--- a/tests/DataResponseTest.php
+++ b/tests/DataResponseTest.php
@@ -40,12 +40,12 @@ class DataResponseTest extends TestCase
     public function testSetResponseFormatter(): void
     {
         $factory = new Psr17Factory();
-        $dataResponse = new DataResponse(['test' => 1], Status::OK, '', $factory);
+        $dataResponse = new DataResponse('test', Status::OK, '', $factory);
         $dataResponse = $dataResponse->withResponseFormatter(new JsonDataResponseFormatter());
         $dataResponse->getBody()->rewind();
 
         $this->assertTrue($dataResponse->hasResponseFormatter());
-        $this->assertSame('{"test":1}', $dataResponse->getBody()->getContents());
+        $this->assertSame('"test"', $dataResponse->getBody()->getContents());
         $this->assertSame(['application/json'], $dataResponse->getHeader('Content-Type'));
     }
 

--- a/tests/DataResponseTest.php
+++ b/tests/DataResponseTest.php
@@ -40,9 +40,23 @@ class DataResponseTest extends TestCase
     public function testSetResponseFormatter(): void
     {
         $factory = new Psr17Factory();
-        $dataResponse = new DataResponse('test', Status::OK, '', $factory);
+        $dataResponse = new DataResponse(['test'=>1], Status::OK, '', $factory);
+        $dataResponse = $dataResponse->withResponseFormatter(new JsonDataResponseFormatter());
+        $dataResponse->getBody()->rewind();
+
+        $this->assertTrue($dataResponse->hasResponseFormatter());
+        $this->assertSame('{"test":1}', $dataResponse->getBody()->getContents());
+        $this->assertSame(['application/json'], $dataResponse->getHeader('Content-Type'));
+    }
+
+    public function testSetEmptyResponseFormatter(): void
+    {
+        $factory = new Psr17Factory();
+        $dataResponse = new DataResponse(null, Status::OK, '', $factory);
         $dataResponse = $dataResponse->withResponseFormatter(new JsonDataResponseFormatter());
 
         $this->assertTrue($dataResponse->hasResponseFormatter());
+        $this->assertSame('', $dataResponse->getBody()->getContents());
+        $this->assertSame(['application/json'], $dataResponse->getHeader('Content-Type'));
     }
 }

--- a/tests/DataResponseTest.php
+++ b/tests/DataResponseTest.php
@@ -40,7 +40,7 @@ class DataResponseTest extends TestCase
     public function testSetResponseFormatter(): void
     {
         $factory = new Psr17Factory();
-        $dataResponse = new DataResponse(['test'=>1], Status::OK, '', $factory);
+        $dataResponse = new DataResponse(['test' => 1], Status::OK, '', $factory);
         $dataResponse = $dataResponse->withResponseFormatter(new JsonDataResponseFormatter());
         $dataResponse->getBody()->rewind();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | allow format empty response


use case:
```php
final class ApiResponseFormatter implements DataResponseFormatterInterface
{
    private DataResponseFormatterInterface $jsonFormatter;

    public function __construct(DataResponseFormatterInterface $jsonFormatter)
    {
        $this->jsonFormatter = $jsonFormatter;
    }

    public function format(DataResponse $dataResponse): ResponseInterface
    {
        $dataResponse = $dataResponse->withData(
            [
                'status' => 'success',
                'error_message' => null,
                'error_code' => null,
                'data' => $dataResponse->getData()
            ]
        );

        return $this->jsonFormatter->format($dataResponse);
    }
}
```
I want to define a formatter that will wrap my response in a specific structure. The null value I also want to format

The same problem is observed in FormatDataResponseAsJson in others