### PR TITLE
Fix overwriting of stream content, add exception throwing

### DIFF
--- a/src/DataResponseFactory.php
+++ b/src/DataResponseFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\DataResponse;
 
 use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Yiisoft\Http\Status;
 
 /**
@@ -13,14 +14,16 @@ use Yiisoft\Http\Status;
 final class DataResponseFactory implements DataResponseFactoryInterface
 {
     private ResponseFactoryInterface $responseFactory;
+    private StreamFactoryInterface $streamFactory;
 
-    public function __construct(ResponseFactoryInterface $responseFactory)
+    public function __construct(ResponseFactoryInterface $responseFactory, StreamFactoryInterface $streamFactory)
     {
         $this->responseFactory = $responseFactory;
+        $this->streamFactory = $streamFactory;
     }
 
     public function createResponse($data = null, int $code = Status::OK, string $reasonPhrase = ''): DataResponse
     {
-        return new DataResponse($data, $code, $reasonPhrase, $this->responseFactory);
+        return new DataResponse($data, $code, $reasonPhrase, $this->responseFactory, $this->streamFactory);
     }
 }

--- a/tests/DataResponseTest.php
+++ b/tests/DataResponseTest.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use stdClass;
 use Yiisoft\DataResponse\Formatter\JsonDataResponseFormatter;
 use Yiisoft\DataResponse\Formatter\XmlDataResponseFormatter;
+use Yiisoft\DataResponse\Tests\Stub\CustomDataResponseFormatter;
 use Yiisoft\DataResponse\Tests\Stub\FakeDataResponseFormatter;
 use Yiisoft\DataResponse\Tests\Stub\LoopDataResponseFormatter;
 use Yiisoft\DataResponse\Tests\Stub\RecursiveDataResponseFormatter;
@@ -353,5 +354,37 @@ final class DataResponseTest extends TestCase
         $this->assertNotSame($dataResponse, $dataResponse->withProtocolVersion('1.0'));
         $this->assertNotSame($dataResponse, $dataResponse->withResponseFormatter(new XmlDataResponseFormatter()));
         $this->assertNotSame($dataResponse, $dataResponse->withStatus(Status::ACCEPTED));
+    }
+
+    public function testFormatterCouldChangeStatusCode(): void
+    {
+        $formatter = (new CustomDataResponseFormatter())->withStatusCode(410);
+        $dataResponse = $this->createDataResponse(['test'])->withResponseFormatter($formatter);
+
+        $this->assertEquals(410, $dataResponse->getStatusCode());
+    }
+
+    public function testFormatterCouldChangeHeaders(): void
+    {
+        $formatter = (new CustomDataResponseFormatter())->withHeaders(['Content-Type' => 'Custom']);
+        $dataResponse = $this->createDataResponse(['test'])->withResponseFormatter($formatter);
+
+        $this->assertEquals('Custom', $dataResponse->getHeaderLine('Content-Type'));
+    }
+
+    public function testFormatterCouldChangeProtocol(): void
+    {
+        $formatter = (new CustomDataResponseFormatter())->withProtocol('2.0');
+        $dataResponse = $this->createDataResponse(['test'])->withResponseFormatter($formatter);
+
+        $this->assertEquals('2.0', $dataResponse->getProtocolVersion());
+    }
+
+    public function testFormatterCouldChangeReasonPhrase(): void
+    {
+        $formatter = (new CustomDataResponseFormatter())->withReasonPhrase('Reason');
+        $dataResponse = $this->createDataResponse(['test'])->withResponseFormatter($formatter);
+
+        $this->assertEquals('Reason', $dataResponse->getReasonPhrase());
     }
 }

--- a/tests/DataResponseTest.php
+++ b/tests/DataResponseTest.php
@@ -251,7 +251,7 @@ final class DataResponseTest extends TestCase
     public function testWithBodyIfDataIsNullWhenOverride(): void
     {
         $dataResponse = $this->createDataResponse('test');
-        $dataResponse->getBody()->rewind();;
+        $dataResponse->getBody()->rewind();
 
         $dataResponse = $dataResponse->withData(null);
         $dataResponse->getBody()->rewind();

--- a/tests/DataResponseTest.php
+++ b/tests/DataResponseTest.php
@@ -31,7 +31,7 @@ final class DataResponseTest extends TestCase
         $this->assertSame('test', $dataResponse->getBody()->getContents());
     }
 
-    public function testCreateResponseWithThrowExceptionIfStreamIsNotReadable(): void
+    public function testCreateResponseThrowsExceptionIfStreamIsNotReadable(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Stream is not readable.');
@@ -41,7 +41,7 @@ final class DataResponseTest extends TestCase
         );
     }
 
-    public function testCreateResponseWithThrowExceptionIfStreamIsNotSeekable(): void
+    public function testCreateResponseThrowsExceptionIfStreamIsNotSeekable(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Stream is not seekable.');
@@ -51,7 +51,7 @@ final class DataResponseTest extends TestCase
         );
     }
 
-    public function testCreateResponseWithThrowExceptionIfStreamIsNotWritable(): void
+    public function testCreateResponseThrowsExceptionIfStreamIsNotWritable(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Stream is not writable.');
@@ -61,7 +61,7 @@ final class DataResponseTest extends TestCase
         );
     }
 
-    public function testCreateResponseWithThrowExceptionIfResourceWasNotSeparatedFromStream(): void
+    public function testCreateResponseThrowsExceptionIfResourceWasNotSeparatedFromStream(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Resource was not separated from the stream.');
@@ -270,7 +270,7 @@ final class DataResponseTest extends TestCase
         $this->assertSame('test2', $dataResponse->getBody()->getContents());
     }
 
-    public function testWithDataThrowExceptionIfWithBodyWasCalled(): void
+    public function testWithDataThrowsExceptionIfWithBodyWasCalled(): void
     {
         $dataResponse = $this->createDataResponse('test1');
         $dataResponse->getBody()->rewind();

--- a/tests/Stub/CustomDataResponseFormatter.php
+++ b/tests/Stub/CustomDataResponseFormatter.php
@@ -1,8 +1,8 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Yiisoft\DataResponse\Tests\Stub;
-
 
 use HttpSoft\Message\Response;
 use Psr\Http\Message\ResponseInterface;
@@ -17,35 +17,35 @@ class CustomDataResponseFormatter implements DataResponseFormatterInterface
     private string $protocol = '1.1';
     private string $reasonPhrase = '';
 
-    public function withStatusCode(int $statusCode): CustomDataResponseFormatter
+    public function withStatusCode(int $statusCode): self
     {
         $new = clone $this;
         $new->statusCode = $statusCode;
         return $new;
     }
 
-    public function withHeaders(array $headers): CustomDataResponseFormatter
+    public function withHeaders(array $headers): self
     {
         $new = clone $this;
         $new->headers = $headers;
         return $new;
     }
 
-    public function withBody(string $body): CustomDataResponseFormatter
+    public function withBody(string $body): self
     {
         $new = clone $this;
         $new->body = $body;
         return $new;
     }
 
-    public function withProtocol(string $protocol): CustomDataResponseFormatter
+    public function withProtocol(string $protocol): self
     {
         $new = clone $this;
         $new->protocol = $protocol;
         return $new;
     }
 
-    public function withReasonPhrase(string $reasonPhrase): CustomDataResponseFormatter
+    public function withReasonPhrase(string $reasonPhrase): self
     {
         $new = clone $this;
         $new->reasonPhrase = $reasonPhrase;

--- a/tests/Stub/CustomDataResponseFormatter.php
+++ b/tests/Stub/CustomDataResponseFormatter.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace Yiisoft\DataResponse\Tests\Stub;
+
+
+use HttpSoft\Message\Response;
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\DataResponse\DataResponse;
+use Yiisoft\DataResponse\DataResponseFormatterInterface;
+
+class CustomDataResponseFormatter implements DataResponseFormatterInterface
+{
+    private int $statusCode = 200;
+    private array $headers = [];
+    private ?string $body = null;
+    private string $protocol = '1.1';
+    private string $reasonPhrase = '';
+
+    public function withStatusCode(int $statusCode): CustomDataResponseFormatter
+    {
+        $new = clone $this;
+        $new->statusCode = $statusCode;
+        return $new;
+    }
+
+    public function withHeaders(array $headers): CustomDataResponseFormatter
+    {
+        $new = clone $this;
+        $new->headers = $headers;
+        return $new;
+    }
+
+    public function withBody(string $body): CustomDataResponseFormatter
+    {
+        $new = clone $this;
+        $new->body = $body;
+        return $new;
+    }
+
+    public function withProtocol(string $protocol): CustomDataResponseFormatter
+    {
+        $new = clone $this;
+        $new->protocol = $protocol;
+        return $new;
+    }
+
+    public function withReasonPhrase(string $reasonPhrase): CustomDataResponseFormatter
+    {
+        $new = clone $this;
+        $new->reasonPhrase = $reasonPhrase;
+        return $new;
+    }
+
+    public function format(DataResponse $dataResponse): ResponseInterface
+    {
+        return new Response(
+            $this->statusCode,
+            $this->headers,
+            $this->body,
+            $this->protocol,
+            $this->reasonPhrase
+        );
+    }
+}

--- a/tests/Stub/ResponseFactoryWithCustomStream.php
+++ b/tests/Stub/ResponseFactoryWithCustomStream.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\DataResponse\Tests\Stub;
+
+use HttpSoft\Message\ResponseTrait;
+use HttpSoft\Message\Stream;
+use HttpSoft\Message\StreamTrait;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+final class ResponseFactoryWithCustomStream implements ResponseFactoryInterface
+{
+    private StreamInterface $stream;
+
+    private function __construct(StreamInterface $stream)
+    {
+        $this->stream = $stream;
+    }
+
+    public static function create(string $stream = 'php://memory', string $mode = 'wb+'): self
+    {
+        return new self(new Stream($stream, $mode));
+    }
+
+    public static function createWithDisabledDetachMethod(): self
+    {
+        return new self(new class() implements StreamInterface {
+            use StreamTrait {
+                detach as private detachInternal;
+            }
+
+            public function __construct()
+            {
+                $this->init('php://memory', 'wb+');
+            }
+
+            public function detach()
+            {
+                $this->detachInternal();
+                return null;
+            }
+        });
+    }
+
+    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
+    {
+        return new class($this->stream, $code, $reasonPhrase) implements ResponseInterface {
+            use ResponseTrait;
+
+            public function __construct(
+                StreamInterface $stream,
+                int $statusCode = 200,
+                string $reasonPhrase = ''
+            ) {
+                $this->init($statusCode, $reasonPhrase, [], $stream);
+            }
+        };
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ namespace Yiisoft\DataResponse\Tests;
 use HttpSoft\Message\ResponseFactory;
 use HttpSoft\Message\ServerRequestFactory;
 use HttpSoft\Message\StreamFactory;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -23,12 +24,17 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     protected function createDataResponse($data, int $status = Status::OK, string $reasonPhrase = ''): DataResponse
     {
-        return new DataResponse($data, $status, $reasonPhrase, new ResponseFactory());
+        return new DataResponse($data, $status, $reasonPhrase, new ResponseFactory(), new StreamFactory());
+    }
+
+    protected function createDataResponseWithCustomResponseFactory(ResponseFactoryInterface $factory): DataResponse
+    {
+        return new DataResponse(null, Status::OK, '', $factory, new StreamFactory());
     }
 
     protected function createDataResponseFactory(): DataResponseFactory
     {
-        return new DataResponseFactory(new ResponseFactory());
+        return new DataResponseFactory(new ResponseFactory(), new StreamFactory());
     }
 
     protected function createStream(string $content = ''): StreamInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -

1. Fixed redefinition of data by the `withData()` method.

```php
$dataResponse = $dataResponse->withData('hello');
$dataResponse->getBody()->rewind();

$dataResponse = $dataResponse->withData('world');
$dataResponse->getBody()->rewind();

// will return now: "hello"
$dataResponse->getBody()->getContents();
```

The data will now be overwritten.

---

2. Fixed overwriting of data in the stream. At the moment, this is implemented as follows:

```php
$this->response->getBody()->rewind();
$this->response->getBody()->write('');
```
But this code doesn't clear the data, it just resets the pointer. In order to properly clear the data, need to use:

```php
ftruncate($resource, 0);
```

> Unfortunately, the PSR interfaces do not provide the ability to clean up the contents of the stream.

It is theoretically possible to create a new thread with a new resource when formatting, but then potentially a large number of resources can be created in a single operation. For example, different data can be redefined in several middleware which leads to reformatting the response and creating new streams accordingly.

---

3. Added throwing an exception when calling the `withData()` method if the user has previously forced the stream to be set by the `withBody()` method.

```php
$dataResponse = $dataResponse->withData($data1);

$dataResponse = $dataResponse->withData($data2);

$dataResponse = $dataResponse->withBody($body);

// An exception will be thrown here:
$dataResponse = $dataResponse->withData($data3);
```

At the moment, nothing is happening at all.
