### PR TITLE
Add `getFormatter()` and `getData()` methods to `DataStream`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.3 under development
 
-- New #107: Add `DataStream` (@vjik)
+- New #107, #110: Add `DataStream` (@vjik)
 - New #107: Add `FormatterInterface` and implementations: `HtmlFormatter`, `JsonFormatter`, `PlainTextFormatter`,
   `XmlFormatter` (@vjik)
 - New #107: Add `DataResponseFactoryInterface` and implementations: `DataResponseFactory`, `FormattedResponseFactory`,

--- a/src/DataStream/DataStream.php
+++ b/src/DataStream/DataStream.php
@@ -47,6 +47,16 @@ final class DataStream implements StreamInterface
     }
 
     /**
+     * Returns the formatter.
+     *
+     * @return FormatterInterface|null The formatter or `null` if not set.
+     */
+    public function getFormatter(): ?FormatterInterface
+    {
+        return $this->formatter;
+    }
+
+    /**
      * Changes the formatter.
      *
      * @param FormatterInterface $formatter The new formatter.
@@ -55,6 +65,16 @@ final class DataStream implements StreamInterface
     {
         $this->formatter = $formatter;
         $this->resetState();
+    }
+
+    /**
+     * Returns the raw data.
+     *
+     * @return mixed The raw data.
+     */
+    public function getData(): mixed
+    {
+        return $this->data;
     }
 
     /**

--- a/tests/DataStream/DataStreamTest.php
+++ b/tests/DataStream/DataStreamTest.php
@@ -24,6 +24,8 @@ final class DataStreamTest extends TestCase
         $stream = new DataStream('test data');
 
         $this->assertFalse($stream->hasFormatter());
+        $this->assertNull($stream->getFormatter());
+        $this->assertSame('test data', $stream->getData());
     }
 
     public function testGetFormattedWithoutFormatter(): void
@@ -37,9 +39,11 @@ final class DataStreamTest extends TestCase
 
     public function testFormatter(): void
     {
-        $stream = new DataStream('test', new JsonFormatter());
+        $formatter = new JsonFormatter();
+        $stream = new DataStream('test', $formatter);
 
         $this->assertTrue($stream->hasFormatter());
+        $this->assertSame($formatter, $stream->getFormatter());
         $this->assertSame('"test"', (string) $stream);
     }
 
@@ -51,6 +55,7 @@ final class DataStreamTest extends TestCase
         $stream->changeFormatter($formatter);
 
         $this->assertTrue($stream->hasFormatter());
+        $this->assertSame($formatter, $stream->getFormatter());
         $this->assertSame('"test"', (string) $stream);
     }
 
@@ -73,6 +78,7 @@ final class DataStreamTest extends TestCase
         $stream->changeData('world');
 
         $this->assertSame('world', (string) $stream);
+        $this->assertSame('world', $stream->getData());
     }
 
     public function testCloseStreamOnChangeData(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
